### PR TITLE
Fix overlapping package names to org.jgroups.protocols.netty and org.…

### DIFF
--- a/src/main/java/org/jgroups/blocks/cs/netty/NettyClient.java
+++ b/src/main/java/org/jgroups/blocks/cs/netty/NettyClient.java
@@ -1,4 +1,4 @@
-//package org.jgroups.blocks.cs;
+//package org.jgroups.blocks.cs.netty;
 //
 //import io.netty.bootstrap.Bootstrap;
 //import io.netty.buffer.PooledByteBufAllocator;
@@ -15,7 +15,7 @@
 //import io.netty.handler.flush.FlushConsolidationHandler;
 //import io.netty.util.concurrent.FutureListener;
 //import io.netty.util.concurrent.GlobalEventExecutor;
-//import org.jgroups.protocols.Netty;
+//import org.jgroups.protocols.netty.Netty;
 //import org.jgroups.stack.IpAddress;
 //
 //import java.io.IOException;

--- a/src/main/java/org/jgroups/blocks/cs/netty/NettyReceiverCallback.java
+++ b/src/main/java/org/jgroups/blocks/cs/netty/NettyReceiverCallback.java
@@ -1,4 +1,4 @@
-package org.jgroups.blocks.cs;
+package org.jgroups.blocks.cs.netty;
 
 import org.jgroups.Address;
 

--- a/src/main/java/org/jgroups/blocks/cs/netty/NettyServer.java
+++ b/src/main/java/org/jgroups/blocks/cs/netty/NettyServer.java
@@ -1,4 +1,4 @@
-package org.jgroups.blocks.cs;
+package org.jgroups.blocks.cs.netty;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;

--- a/src/main/java/org/jgroups/protocols/netty/Netty.java
+++ b/src/main/java/org/jgroups/protocols/netty/Netty.java
@@ -1,12 +1,12 @@
-package org.jgroups.protocols;
-
+package org.jgroups.protocols.netty;
 
 import io.netty.channel.unix.Errors;
-import org.jgroups.blocks.cs.NettyReceiverCallback;
-import org.jgroups.blocks.cs.NettyServer;
+import org.jgroups.blocks.cs.netty.NettyReceiverCallback;
+import org.jgroups.blocks.cs.netty.NettyServer;
 import org.jgroups.Address;
 import org.jgroups.PhysicalAddress;
 import org.jgroups.annotations.Property;
+import org.jgroups.protocols.TP;
 import org.jgroups.stack.IpAddress;
 
 import java.net.BindException;

--- a/src/main/resources/netty.xml
+++ b/src/main/resources/netty.xml
@@ -8,7 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="urn:org:jgroups"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
-    <Netty bind_port="7800"
+    <netty.Netty bind_port="7800"
          use_native_transport="false"
          bind_addr="192.168.1.12"
          thread_pool.min_threads="0"


### PR DESCRIPTION
…jgroups.blocks.cs.netty

The packages currently in use are used by `jgroups.jar` already thus this won't work with the security manager.