### PR TITLE
Changed JGroups version to 5.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <version.jgroups>5.0.0.Beta1</version.jgroups>
-        <version.netty>4.1.49.Final</version.netty>
+        <version.netty>4.1.50.Final</version.netty>
     </properties>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <version.jgroups>4.2.3.Final</version.jgroups>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <version.jgroups>5.0.0.Beta1</version.jgroups>
         <version.netty>4.1.49.Final</version.netty>
     </properties>
     <repositories>


### PR DESCRIPTION
This means that Netty will run only in JGroups 5 and higher. But I think it makes sense to start there anyway...
In the worst case, and there's demand, we can always backport from master to 4.x